### PR TITLE
Fix Clang-15 compilation warnings

### DIFF
--- a/src/json/iwbinn.c
+++ b/src/json/iwbinn.c
@@ -234,15 +234,15 @@ BOOL binn_create_object(binn *object) {
   return binn_create(object, BINN_OBJECT, 0, NULL);
 }
 
-binn* binn_list() {
+binn* binn_list(void) {
   return binn_new(BINN_LIST, 0, 0);
 }
 
-binn* binn_map() {
+binn* binn_map(void) {
   return binn_new(BINN_MAP, 0, 0);
 }
 
-binn* binn_object() {
+binn* binn_object(void) {
   return binn_new(BINN_OBJECT, 0, 0);
 }
 
@@ -2753,7 +2753,7 @@ void* binn_object_object(void *obj, const char *key) {
   return value;
 }
 
-BINN_PRIVATE binn* binn_alloc_item() {
+BINN_PRIVATE binn* binn_alloc_item(void) {
   binn *item;
   item = (binn*) binn_malloc(sizeof(binn));
   if (item) {

--- a/src/json/iwbinn.h
+++ b/src/json/iwbinn.h
@@ -269,9 +269,9 @@ BOOL binn_save_header(binn *item);
 
 // create a new binn allocating memory for the structure
 IW_ALLOC binn* binn_new(int type, int size, void *buffer);
-IW_ALLOC binn* binn_list();
-IW_ALLOC binn* binn_map();
-IW_ALLOC binn* binn_object();
+IW_ALLOC binn* binn_list(void);
+IW_ALLOC binn* binn_map(void);
+IW_ALLOC binn* binn_object(void);
 
 // create a new binn storing the structure on the stack
 BOOL binn_create(binn *item, int type, int size, void *buffer);
@@ -353,7 +353,7 @@ IW_ALLOC IW_INLINE binn* binn_bool(BOOL value) {
   return binn_value(BINN_BOOL, &value, 0, NULL);
 }
 
-IW_ALLOC IW_INLINE binn* binn_null() {
+IW_ALLOC IW_INLINE binn* binn_null(void) {
   return binn_value(BINN_NULL, NULL, 0, NULL);
 }
 

--- a/src/json/iwjson.c
+++ b/src/json/iwjson.c
@@ -2052,12 +2052,12 @@ static iwrc _jbl_node_from_binn_impl(
         return JBL_ERROR_INVALID;
       }
       if (bn->type == BINN_OBJECT) {
-        for (int i = 0; binn_object_next2(&iter, &key, &klidx, &bv); ++i) {
+        while (binn_object_next2(&iter, &key, &klidx, &bv)) {
           rc = _jbl_node_from_binn_impl(ctx, &bv, parent, key, klidx, clone_strings);
           RCRET(rc);
         }
       } else if (bn->type == BINN_MAP) {
-        for (int i = 0; binn_map_next(&iter, &klidx, &bv); ++i) {
+        while (binn_map_next(&iter, &klidx, &bv)) {
           rc = _jbl_node_from_binn_impl(ctx, &bv, parent, 0, klidx, clone_strings);
           RCRET(rc);
         }
@@ -2980,7 +2980,7 @@ static const char* _jbl_ecodefn(locale_t locale, uint32_t ecode) {
   return 0;
 }
 
-iwrc jbl_init() {
+iwrc jbl_init(void) {
   static int _jbl_initialized = 0;
   if (!__sync_bool_compare_and_swap(&_jbl_initialized, 0, 1)) {
     return 0;

--- a/src/kv/examples/compoundkeys1.c
+++ b/src/kv/examples/compoundkeys1.c
@@ -111,7 +111,7 @@ finish:
   return rc;
 }
 
-int main() {
+int main(void) {
   iwrc rc = run();
   if (rc) {
     iwlog_ecode_error3(rc);

--- a/src/kv/examples/cursors1.c
+++ b/src/kv/examples/cursors1.c
@@ -106,7 +106,7 @@ finish:
   return rc;
 }
 
-int main() {
+int main(void) {
   iwrc rc = run();
   if (rc) {
     iwlog_ecode_error3(rc);

--- a/src/kv/examples/example1.c
+++ b/src/kv/examples/example1.c
@@ -2,7 +2,7 @@
 #include <string.h>
 #include <stdlib.h>
 
-int main() {
+int main(void) {
   IWKV_OPTS opts = {
     .path   = "example1.db",
     .oflags = IWKV_TRUNC // Cleanup database before open

--- a/src/platform/unix/unix.c
+++ b/src/platform/unix/unix.c
@@ -354,7 +354,7 @@ iwrc iwp_exec_path(char *opath, size_t opath_maxlen) {
 #endif
 }
 
-uint16_t iwp_num_cpu_cores() {
+uint16_t iwp_num_cpu_cores(void) {
   long res = sysconf(_SC_NPROCESSORS_ONLN);
   return (uint16_t) (res > 0 ? res : 1);
 }
@@ -406,7 +406,7 @@ void iwp_set_current_thread_name(const char *name) {
 #endif
 }
 
-static iwrc _iwp_init_impl() {
+static iwrc _iwp_init_impl(void) {
   iwp_page_size(); // init statics
   return 0;
 }

--- a/src/platform/win32/win32.c
+++ b/src/platform/win32/win32.c
@@ -66,7 +66,7 @@ iwrc iwp_fdatasync(HANDLE fh) {
 
 static SYSTEM_INFO sysinfo;
 
-static void _iwp_getsysinfo() {
+static void _iwp_getsysinfo(void) {
   GetSystemInfo(&sysinfo);
 }
 
@@ -78,7 +78,7 @@ size_t iwp_alloc_unit(void) {
   return sysinfo.dwAllocationGranularity;
 }
 
-uint16_t iwp_num_cpu_cores() {
+uint16_t iwp_num_cpu_cores(void) {
   return sysinfo.dwNumberOfProcessors;
 }
 
@@ -314,7 +314,7 @@ size_t iwp_tmpdir(char *out, size_t len) {
   return GetTempPathA(len, out);
 }
 
-static iwrc _iwp_init_impl() {
+static iwrc _iwp_init_impl(void) {
   _iwp_getsysinfo();
   return 0;
 }

--- a/src/utils/iwconv.c
+++ b/src/utils/iwconv.c
@@ -438,7 +438,6 @@ static const char* skipwhite(const char *q) {
 double iwstrtod(const char *str, char **end) {
   double d = 0.0;
   int sign;
-  int n = 0;
   const char *p, *a;
 
   a = p = str;
@@ -457,7 +456,6 @@ double iwstrtod(const char *str, char **end) {
     while (*p && isdigit(*p)) {
       d = d * 10.0 + (double) (*p - '0');
       ++p;
-      ++n;
     }
     a = p;
   } else if (*p != '.') {
@@ -476,7 +474,6 @@ double iwstrtod(const char *str, char **end) {
         f += base * (*p - '0');
         base /= 10.0;
         ++p;
-        ++n;
       }
     }
     d += f * sign;

--- a/src/utils/mt19937ar.c
+++ b/src/utils/mt19937ar.c
@@ -62,7 +62,7 @@ static int mti = N + 1;     /* mti==N+1 means mt[N] is not initialized */
 static pthread_spinlock_t lock;
 static volatile int mt_initialized;
 
-void init_mt19937ar() {
+void init_mt19937ar(void) {
   if (!__sync_bool_compare_and_swap(&mt_initialized, 0, 1)) {
     return;  // initialized already
   }
@@ -71,13 +71,13 @@ void init_mt19937ar() {
 
 __attribute__((constructor))
 
-void lock_constructor() {
+void lock_constructor(void) {
   init_mt19937ar();
 }
 
 __attribute__((destructor))
 
-void lock_destructor() {
+void lock_destructor(void) {
   if (!__sync_bool_compare_and_swap(&mt_initialized, 1, 0)) {
     return;  // initialized already
   }


### PR DESCRIPTION
Building debug configuration of iowow with clang-15 gives a lot
of `-Wstrict-prototypes` and `-Wunused-but-set-variable` warnings.

To reproduce install clang-15 and configure with:
````
env CC=clang-15 CFLAGS='-Wfatal-errors -Werror -Wall' cmake . -Bbuild -DCMAKE_BUILD_TYPE=Debug
````