### PR TITLE
Correct UCS-16 surrogate pair start code point. Fix #51.

### DIFF
--- a/src/json/iwjson.c
+++ b/src/json/iwjson.c
@@ -612,7 +612,7 @@ iwrc _jbl_write_json_string(const char *str, int len, jbl_json_printer pt, void 
       if (sz < 0) {
         return JBL_ERROR_PARSE_INVALID_UTF8;
       }
-      if (cp > 0x0010000UL) {
+      if (cp >= 0x0010000UL) {
         uint32_t hs = 0xD800, ls = 0xDC00; // surrogates
         cp -= 0x0010000UL;
         hs |= ((cp >> 10) & 0x3FF);


### PR DESCRIPTION
The code points that must be encoded as surrogate pairs start already at `0x0010000`, not at the next one, so we need `>=` instead of `>` in the conditional.