### PR TITLE
Fix installation paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/")
 include(CMakeToolsHelpers OPTIONAL)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -225,6 +225,10 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/tmpl/iwcfg.h ${PROJECT_GENERATED_DIR}
 file(GLOB PROJECT_GENERATED_HDRS ${PROJECT_GENERATED_DIR}/*.h)
 list(APPEND ALL_HDRS ${PROJECT_GENERATED_HDRS})
 
+cmake_path(APPEND includedir_for_pc_file "\${prefix}" "${CMAKE_INSTALL_INCLUDEDIR}")
+cmake_path(APPEND libdir_for_pc_file "\${prefix}" "${CMAKE_INSTALL_LIBDIR}")
+cmake_path(APPEND bindir_for_pc_file "\${prefix}" "${CMAKE_INSTALL_BINDIR}")
+
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/tmpl/libiowow.pc.in ${PROJECT_GENERATED_DIR}/libiowow.pc @ONLY)
 
 if (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")

--- a/src/tmpl/libiowow.pc.in
+++ b/src/tmpl/libiowow.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
-exec_prefix=${prefix}/@CMAKE_INSTALL_BINDIR@
-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+exec_prefix=@bindir_for_pc_file@
+libdir=@libdir_for_pc_file@
+includedir=@includedir_for_pc_file@
 
 Name: @PROJECT_NAME@
 Description: @PROJECT_DESCRIPTION_SUMMARY@


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/256797

`prefix` in the original pkg-config configuration resulted in errors in the Nix package manager build, which should be addressed upstream

This is a bug in the Nix build before the change of the source code.

```
error: builder for '/nix/store/z4qv8mhrvb8zp0vfwmjkcgk0v10qr4yr-iowow-1.4.16.drv' failed with exit code 1;
       last 10 log lines:
       > patching script interpreter paths in /nix/store/sgw3635d3spw7p25p1hhnhykv0lnlap1-iowow-1.4.16
       > stripping (with command strip and flags -S -p) in  /nix/store/sgw3635d3spw7p25p1hhnhykv0lnlap1-iowow-1.4.16/lib
       > Broken paths found in a .pc file! /nix/store/sgw3635d3spw7p25p1hhnhykv0lnlap1-iowow-1.4.16/lib/pkgconfig/libiowow.pc
       > The following lines have issues (specifically '//' in paths).
       > 2:exec_prefix=${prefix}//nix/store/sgw3635d3spw7p25p1hhnhykv0lnlap1-iowow-1.4.16/bin
       > 3:libdir=${prefix}//nix/store/sgw3635d3spw7p25p1hhnhykv0lnlap1-iowow-1.4.16/lib
       > 4:includedir=${prefix}//nix/store/sgw3635d3spw7p25p1hhnhykv0lnlap1-iowow-1.4.16/include
       > It is very likely that paths are being joined improperly.
       > ex: "${prefix}/@CMAKE_INSTALL_LIBDIR@" should be "@CMAKE_INSTALL_FULL_LIBDIR@"
       > Please see https://github.com/NixOS/nixpkgs/issues/144170 for more details.
       For full logs, run 'nix log /nix/store/z4qv8mhrvb8zp0vfwmjkcgk0v10qr4yr-iowow-1.4.16.drv'.
```