### PR TITLE
iwjsreg.c: use fsync for fdatasync on macOS

### DIFF
--- a/src/json/iwjsreg.c
+++ b/src/json/iwjsreg.c
@@ -12,6 +12,10 @@
 #include <string.h>
 #include <stdlib.h>
 
+#ifdef __APPLE__
+#define fdatasync fsync
+#endif
+
 struct iwjsreg {
   struct iwpool    *pool;
   struct jbl_node  *root;


### PR DESCRIPTION
I guess this did not fail for me earlier, since gcc13 accepted undeclared functions, but gcc14 does not now.

Examples of `fsync` being used instead of `fdatasync`:
https://github.com/rakshasa/rtorrent/commit/5ce84929e44fbe3f8d6cf142e3133f43afa4071f
https://github.com/php/php-src/pull/6882