### PR TITLE
Fix out-of-bounds pointer from iwrb_begin() at wrap boundary

### DIFF
--- a/src/utils/iwrb.c
+++ b/src/utils/iwrb.c
@@ -72,6 +72,8 @@ void* iwrb_begin(const struct iwrb *rb) {
   }
   if (rb->pos < 0) {
     return rb->buf;
+  } else if ((size_t) rb->pos == rb->len) {
+    return rb->buf;
   } else {
     return rb->buf + rb->pos * rb->usize;
   }


### PR DESCRIPTION
## Bug

`iwrb_begin()` in `src/utils/iwrb.c` does not special-case the wrap
boundary `rb->pos == rb->len`, unlike `iwrb_put()` and
`iwrb_iter_prev()` which already handle this exact case.

When a ring buffer has just been filled to exactly its capacity
(`rb->pos == rb->len`), `iwrb_begin()` falls into the final `else`
branch and returns `rb->buf + rb->pos * rb->usize`, i.e. an address
one element past the end of the buffer's single `malloc` allocation
(`iwrb_create()` allocates `sizeof(*rb) + usize * len` bytes total),
instead of wrapping back to `rb->buf` (index 0).

## Repro

```c
struct iwrb *rb = iwrb_create(1, 6);
for (int i = 0; i < 12; i++) {
  char c = 'A' + i;
  iwrb_put(rb, &c);
}
// rb->pos == 6 == rb->len (exact wrap boundary)
char *p = iwrb_begin(rb);
// p == rb->buf + 6, one byte past the valid [0, 6) range
```

Before the fix, `p` points one byte past the buffer's allocation
(confirmed via pointer arithmetic against the known single-allocation
layout of `iwrb_create()`; dereferencing reads uninitialized/adjacent
heap memory). After the fix, `p == rb->buf` (offset 0), matching the
wrap-handling already used elsewhere in this file.

## Fix

Add the same `(size_t) rb->pos == rb->len` special case that
`iwrb_put()` (line ~40) and `iwrb_iter_prev()` (line ~117) already use,
so `iwrb_begin()` returns `rb->buf` at the wrap point instead of an
out-of-bounds address.

Minimal, 2-line diff; no behavior change for any non-boundary case.